### PR TITLE
[Fix](main) Fix lowercase username parsing bug

### DIFF
--- a/main.py
+++ b/main.py
@@ -111,6 +111,7 @@ def confirm(msg: catbot.Message):
         return
 
     wikimedia_username = '_'.join(user_input_token[1:])
+    wikimedia_username = wikimedia_username[0].upper() + wikimedia_username[1:]
     bot.send_message(msg.chat.id, text=config['messages']['confirm_checking'])
     global_user_info_query = site.api(**{
         "action": "query",


### PR DESCRIPTION
Change the first char of `wikimedia_username` to uppercase. It is convinced that this is the problem that blocked me out from confirmation...